### PR TITLE
Create deploy-jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/deploy-jekyll-gh-pages.yml
+++ b/.github/workflows/deploy-jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new workflow for deploying a Jekyll site to GitHub Pages. The workflow is defined in the `.github/workflows/deploy-jekyll-gh-pages.yml` file and includes steps for building and deploying the site.

Key changes include:

* **Workflow Setup:**
  * Added a new workflow named `Deploy GitHub Pages` to handle the deployment process.
  * Configured the workflow to trigger on pushes to the `main` branch and allow manual runs from the Actions tab.

* **Permissions and Concurrency:**
  * Set permissions for the `GITHUB_TOKEN` to allow reading contents, writing pages, and writing id-token.
  * Configured concurrency to allow only one concurrent deployment, ensuring in-progress runs are not canceled.

* **Build and Deployment Jobs:**
  * Defined a build job that checks out the repository, sets up GitHub Pages, builds the site with Jekyll, and uploads the build artifact.
  * Defined a deployment job that deploys the built site to GitHub Pages, dependent on the successful completion of the build job.