### PR TITLE
Update step names for clarity in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,7 +76,7 @@ jobs:
       - run: |
           echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
-      - name: Codecov
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.1.1
 
       - name: Upload dotnet test results

--- a/.github/workflows/dotnetdev.yml
+++ b/.github/workflows/dotnetdev.yml
@@ -76,7 +76,7 @@ jobs:
       - run: |
           echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
-      - name: Codecov
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.1.1
 
       - name: Upload dotnet test results


### PR DESCRIPTION
The pull request updates step names for clarity in GitHub Actions workflows by renaming the "Codecov" step to "Upload coverage reports to Codecov" in both `dotnet.yml` and `dotnetdev.yml` workflows. No functional changes were made.